### PR TITLE
feat(losses): 实现交叉熵损失函数及单元测试

### DIFF
--- a/src/nn/losses/__init__.py
+++ b/src/nn/losses/__init__.py
@@ -7,4 +7,6 @@
 3. 为反向传播提供损失梯度入口
 """
 
-__all__: list[str] = []
+from src.nn.losses.crossEntropyLoss import CrossEntropyLoss
+
+__all__: list[str] = ["CrossEntropyLoss"]

--- a/src/nn/losses/crossEntropyLoss.py
+++ b/src/nn/losses/crossEntropyLoss.py
@@ -1,0 +1,124 @@
+"""
+交叉熵损失函数的实现
+
+1. 实现 softmax 和 cross-entropy 的联合损失
+2. 支持前向传播计算损失值
+3. 支持对 logits 的反向传播计算输入梯度
+"""
+
+import numpy as np
+
+
+class CrossEntropyLoss:
+    """
+    交叉熵损失函数
+
+    说明
+        1. 输入为模型输出的 logits, 而不是softmax 后的概率分布
+        2. 标签应该是整数形式的类别索引, 而不是 one-hot 编码
+        3. 内部自动完成 softmax 和交叉熵的计算, 以提高数值稳定性
+
+    计算公式:
+    1. softmax(logits) = exp(logits) / sum(exp(logits))
+    2. cross_entropy_loss = -log(softmax(logits)[true_class])
+
+    """
+
+    def __init__(self, epsilon: float = 1e-12) -> None:
+        """
+        初始化交叉熵损失函数
+
+        Args:
+            epsilon(float): 用于数值稳定性的微小常数, 避免 log(0) 的情况
+        """
+        if epsilon <= 0.0:
+            raise ValueError("epsilon 必须是一个正数")
+
+        self.epsilon = epsilon
+        # 缓存 softmax 输出的概率分布和标签, 以供反向传播使用
+        self.probabilities: np.ndarray | None = None
+        # 标签应该是整数形式的类别索引, 而不是 one-hot 编码
+        self.targetLabels: np.ndarray | None = None
+        self.batchSize: int | None = None
+
+    def forward(self, logits: np.ndarray, targetLabels: np.ndarray) -> float:
+        """
+        计算交叉熵损失
+
+        Args:
+            logits (np.ndarray): 模型输出的 logits, 形状为 (batchSize, numClasses)
+            targetLabels (np.ndarray): 真实标签的类别索引, 形状为 (batchSize,)
+
+        Returns:
+            float: 当前批次的平均损失
+
+
+        """
+        if logits.ndim != 2:
+            raise ValueError("logits 必须是二维数组")
+
+        if targetLabels.ndim != 1:
+            raise ValueError("targetLabels 必须是一维数组")
+
+        batchSize, classCount = logits.shape
+
+        if batchSize == 0:
+            raise ValueError("batchSize 必须大于 0")
+
+        if classCount == 0:
+            raise ValueError("classCount 必须大于 0")
+
+        if targetLabels.shape[0] != batchSize:
+            raise ValueError(
+                f"targetLabels 的 batchSize 不匹配, 期望 {batchSize}, 实际为 {targetLabels.shape[0]}"
+            )
+
+        if not np.issubdtype(targetLabels.dtype, np.integer):
+            raise ValueError("targetLabels 必须是整数类型的数组")
+
+        if np.any(targetLabels < 0) or np.any(targetLabels >= classCount):
+            raise ValueError("targetLabels 中的类别索引必须在 [0, classCount) 范围内")
+
+        # 为了数值稳定性, 在计算 softmax 之前先减去每行的最大值
+        shiftedLogits = logits - np.max(logits, axis=1, keepdims=True)
+
+        # 计算 softmax 输出的指数部分
+        expLogits = np.exp(shiftedLogits)
+        # 计算 softmax 输出的概率分布
+        probabilities = expLogits / np.sum(expLogits, axis=1, keepdims=True)
+
+        # 缓存 softmax 输出的概率分布和标签, 以供反向传播使用
+        selectedprobabilities = probabilities[np.arange(batchSize), targetLabels]
+        # 为了数值稳定性, 避免 log(0) 的情况, 对概率值进行裁剪
+        clippedprobabilities = np.clip(selectedprobabilities, self.epsilon, 1.0)
+
+        loss = -np.mean(np.log(clippedprobabilities))
+        # 缓存 softmax 输出的概率分布和标签, 以供反向传播使用
+        self.probabilities = probabilities
+        self.targetLabels = targetLabels
+        self.batchSize = batchSize
+
+        return float(loss)
+
+    def backward(self) -> np.ndarray:
+        """
+        计算输入 logits 的梯度
+
+        Returns:
+            np.ndarray: 输入 logits 的梯度, 形状为 (batchSize, numClasses)
+
+        计算公式:
+            inputGradient = (softmax(logits) - one_hot(targetLabels)) / batchSize
+        """
+        if self.probabilities is None:
+            raise ValueError("调用 backward 之前必须先调用 forward")
+        if self.targetLabels is None:
+            raise ValueError("targetLabels 缓存为空，无法执行 backward")
+        if self.batchSize is None:
+            raise ValueError("batchSize 缓存为空，无法执行 backward")
+
+        inputGradient = self.probabilities.copy()
+        inputGradient[np.arange(self.batchSize), self.targetLabels] -= 1.0
+        inputGradient /= self.batchSize
+
+        return inputGradient

--- a/tests/testCrossEntropyLoss.py
+++ b/tests/testCrossEntropyLoss.py
@@ -1,0 +1,173 @@
+"""
+交叉熵损失函数测试模块
+
+功能：
+1. 测试前向传播损失值
+2. 测试反向传播梯度
+3. 测试输入校验逻辑
+"""
+
+import numpy as np
+import pytest
+
+from src.nn.losses import CrossEntropyLoss
+
+
+def testInitRaisesWhenEpsilonIsInvalid() -> None:
+    """
+    测试 epsilon 非法时抛出异常
+    """
+    with pytest.raises(ValueError):
+        CrossEntropyLoss(epsilon=0.0)
+
+    with pytest.raises(ValueError):
+        CrossEntropyLoss(epsilon=-1e-6)
+
+
+def testForwardReturnsExpectedLoss() -> None:
+    """
+    测试前向传播返回正确损失
+    """
+    lossFunction = CrossEntropyLoss()
+
+    logits = np.array(
+        [
+            [2.0, 1.0, 0.1],
+            [0.5, 1.5, 0.3],
+        ],
+        dtype=np.float64,
+    )
+    targetLabels = np.array([0, 1], dtype=np.int64)
+
+    loss = lossFunction.forward(logits, targetLabels)
+
+    shiftedLogits = logits - np.max(logits, axis=1, keepdims=True)
+    expLogits = np.exp(shiftedLogits)
+    probabilities = expLogits / np.sum(expLogits, axis=1, keepdims=True)
+    selectedProbabilities = probabilities[np.arange(2), targetLabels]
+    expectedLoss = -np.mean(np.log(selectedProbabilities))
+
+    np.testing.assert_allclose(loss, expectedLoss)
+
+
+def testBackwardReturnsExpectedGradient() -> None:
+    """
+    测试反向传播返回正确梯度
+    """
+    lossFunction = CrossEntropyLoss()
+
+    logits = np.array(
+        [
+            [2.0, 1.0, 0.1],
+            [0.5, 1.5, 0.3],
+        ],
+        dtype=np.float64,
+    )
+    targetLabels = np.array([0, 1], dtype=np.int64)
+
+    lossFunction.forward(logits, targetLabels)
+    inputGradient = lossFunction.backward()
+
+    shiftedLogits = logits - np.max(logits, axis=1, keepdims=True)
+    expLogits = np.exp(shiftedLogits)
+    probabilities = expLogits / np.sum(expLogits, axis=1, keepdims=True)
+
+    expectedGradient = probabilities.copy()
+    expectedGradient[np.arange(2), targetLabels] -= 1.0
+    expectedGradient /= 2
+
+    np.testing.assert_allclose(inputGradient, expectedGradient)
+
+
+def testForwardRaisesWhenLogitsIsNot2D() -> None:
+    """
+    测试 logits 不是二维数组时抛出异常
+    """
+    lossFunction = CrossEntropyLoss()
+
+    logits = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    targetLabels = np.array([0], dtype=np.int64)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(logits, targetLabels)
+
+
+def testForwardRaisesWhenTargetLabelsIsNot1D() -> None:
+    """
+    测试 targetLabels 不是一维数组时抛出异常
+    """
+    lossFunction = CrossEntropyLoss()
+
+    logits = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+    targetLabels = np.array([[0]], dtype=np.int64)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(logits, targetLabels)
+
+
+def testForwardRaisesWhenBatchSizeIsZero() -> None:
+    """
+    测试空批次输入时抛出异常
+    """
+    lossFunction = CrossEntropyLoss()
+
+    logits = np.empty((0, 3), dtype=np.float64)
+    targetLabels = np.empty((0,), dtype=np.int64)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(logits, targetLabels)
+
+
+def testForwardRaisesWhenTargetCountMismatch() -> None:
+    """
+    测试标签数量与 batchSize 不一致时抛出异常
+    """
+    lossFunction = CrossEntropyLoss()
+
+    logits = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [0.5, 0.2, 1.2],
+        ],
+        dtype=np.float64,
+    )
+    targetLabels = np.array([0], dtype=np.int64)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(logits, targetLabels)
+
+
+def testForwardRaisesWhenTargetLabelsAreNotIntegers() -> None:
+    """
+    测试标签不是整数类型时抛出异常
+    """
+    lossFunction = CrossEntropyLoss()
+
+    logits = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+    targetLabels = np.array([0.0], dtype=np.float64)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(logits, targetLabels)
+
+
+def testForwardRaisesWhenTargetLabelsOutOfRange() -> None:
+    """
+    测试标签索引越界时抛出异常
+    """
+    lossFunction = CrossEntropyLoss()
+
+    logits = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+    targetLabels = np.array([3], dtype=np.int64)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(logits, targetLabels)
+
+
+def testBackwardRaisesWhenForwardNotCalled() -> None:
+    """
+    测试未先调用 forward 时调用 backward 会抛出异常
+    """
+    lossFunction = CrossEntropyLoss()
+
+    with pytest.raises(ValueError):
+        lossFunction.backward()


### PR DESCRIPTION
- 新增 CrossEntropyLoss 类，联合实现 softmax 与交叉熵计算以提升数值稳定性
- forward 阶段对 logits 做 max-shift 处理并缓存概率分布，供 backward 复用
- backward 阶段按 (softmax - one_hot) / batchSize 公式计算 logits 梯度
- 对 epsilon、logits 维度、batchSize、标签类型及范围均添加严格校验
- 新增完整单元测试，覆盖前向损失值、反向梯度及各类异常输入场景
- 在 losses/__init__.py 中导出 CrossEntropyLoss

close #11

## Summary by Sourcery

添加一个数值稳定的交叉熵损失实现，以及相应的单元测试和导出配置。

新特性：
- 引入 `CrossEntropyLoss` 类，将 softmax 与基于 logits 的交叉熵结合在一起，并包含输入校验以及用于反向传播的缓存状态。

测试：
- 为 `CrossEntropyLoss` 添加全面测试，覆盖前向损失值、反向梯度，以及在形状、批大小、标签类型与取值范围等方面的无效输入场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a numerically stable cross-entropy loss implementation with corresponding unit tests and exports.

New Features:
- Introduce CrossEntropyLoss class that combines softmax and cross-entropy over logits with input validation and cached state for backpropagation.

Tests:
- Add comprehensive tests for CrossEntropyLoss covering forward loss values, backward gradients, and invalid input scenarios such as shapes, batch size, label type, and range.

</details>