### PR TITLE
feat(losses): 新增 MSELoss 均方误差损失函数及测试

### DIFF
--- a/src/nn/losses/__init__.py
+++ b/src/nn/losses/__init__.py
@@ -8,5 +8,6 @@
 """
 
 from src.nn.losses.crossEntropyLoss import CrossEntropyLoss
+from src.nn.losses.mseLoss import MSELoss
 
-__all__: list[str] = ["CrossEntropyLoss"]
+__all__: list[str] = ["CrossEntropyLoss", "MSELoss"]

--- a/src/nn/losses/mseLoss.py
+++ b/src/nn/losses/mseLoss.py
@@ -1,0 +1,91 @@
+"""
+均方误差函数的实现
+
+1. 实现回归任务的均方误差损失函数
+2. 支持前向传播计算损失值
+3. 支持反向传播计算梯度值
+"""
+
+import numpy as np
+
+
+class MSELoss:
+    """
+    均方误差损失函数类
+
+    说明:
+        1. 输入为模型的预测值和真实目标值
+        2. 预测值和目标值必须具有相同的形状
+        3. 返回整个批次的平均损失值
+
+    计算公式:
+        loss = mean((predictions - targets) ** 2)
+    """
+
+    def __init__(self):
+        """
+        初始化均方误差损失函数
+
+        """
+        # 存储预测值和目标值以供反向传播使用
+        self.predictions: np.ndarray | None = None
+        self.targets: np.ndarray | None = None
+        # 存储元素数量以计算平均损失
+        self.elementCount: int | None = None
+
+    def forward(self, predictions: np.ndarray, targets: np.ndarray) -> float:
+        """
+        计算均方误差损失
+
+        Args:
+            predictions (np.ndarray): 模型预测值
+            targets (np.ndarray): 真实目标值
+
+        Returns:
+            float: 当前批次的平均损失
+        """
+        if predictions.ndim == 0:
+            raise ValueError("predictions 不能是标量")
+        if targets.ndim == 0:
+            raise ValueError("targets 不能是标量")
+
+        if predictions.shape != targets.shape:
+            raise ValueError(
+                "predictions 和 targets 的形状必须相同"
+                f"但得到 predictions.shape={predictions.shape}"
+                f"targets.shape={targets.shape}"
+            )
+
+        if predictions.size == 0:
+            raise ValueError("predictions 不能为空")
+
+        # 计算元素数量以便后续平均
+        difference = predictions - targets
+        loss = np.mean(difference**2)
+
+        self.predictions = predictions
+        self.targets = targets
+        self.elementCount = predictions.size
+
+        return float(loss)
+
+    def backward(self) -> np.ndarray:
+        """
+        计算损失函数对预测值的梯度
+
+        Returns:
+            np.ndarray: 预测值对应的梯度
+
+        计算公式:
+            dLoss / dPredictions = 2 * (predictions - targets) / N
+        """
+        if self.predictions is None:
+            raise ValueError("必须先调用 forward 方法计算损失值")
+        if self.targets is None:
+            raise ValueError("targets 缓存为空, 无法执行 backward")
+        if self.elementCount is None:
+            raise ValueError("elementCount 缓存为空, 无法执行 backward")
+
+        inputGradient = 2 * (self.predictions - self.targets) / self.elementCount
+
+        return inputGradient

--- a/tests/testMSELoss.py
+++ b/tests/testMSELoss.py
@@ -1,0 +1,170 @@
+"""
+均方误差损失函数测试模块
+
+功能：
+1. 测试前向传播损失值
+2. 测试反向传播梯度
+3. 测试输入校验逻辑
+"""
+
+import numpy as np
+import pytest
+
+from src.nn.losses import MSELoss
+
+
+def testForwardReturnsExpectedLoss() -> None:
+    """
+    测试前向传播返回正确损失值
+    """
+    lossFunction = MSELoss()
+
+    predictions = np.array(
+        [
+            [1.0],
+            [2.0],
+            [3.0],
+        ],
+        dtype=np.float64,
+    )
+    targets = np.array(
+        [
+            [1.0],
+            [1.0],
+            [5.0],
+        ],
+        dtype=np.float64,
+    )
+
+    loss = lossFunction.forward(predictions, targets)
+
+    expectedLoss = np.mean((predictions - targets) ** 2)
+
+    np.testing.assert_allclose(loss, expectedLoss)
+
+
+def testBackwardReturnsExpectedGradient() -> None:
+    """
+    测试反向传播返回正确梯度
+    """
+    lossFunction = MSELoss()
+
+    predictions = np.array(
+        [
+            [1.0],
+            [2.0],
+            [3.0],
+        ],
+        dtype=np.float64,
+    )
+    targets = np.array(
+        [
+            [1.0],
+            [1.0],
+            [5.0],
+        ],
+        dtype=np.float64,
+    )
+
+    lossFunction.forward(predictions, targets)
+    inputGradient = lossFunction.backward()
+
+    expectedGradient = 2.0 * (predictions - targets) / predictions.size
+
+    np.testing.assert_allclose(inputGradient, expectedGradient)
+
+
+def testForwardRaisesWhenPredictionsIsScalar() -> None:
+    """
+    测试 predictions 是标量时抛出异常
+    """
+    lossFunction = MSELoss()
+
+    predictions = np.array(1.0)
+    targets = np.array([1.0], dtype=np.float64)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(predictions, targets)
+
+
+def testForwardRaisesWhenTargetsIsScalar() -> None:
+    """
+    测试 targets 是标量时抛出异常
+    """
+    lossFunction = MSELoss()
+
+    predictions = np.array([1.0], dtype=np.float64)
+    targets = np.array(1.0)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(predictions, targets)
+
+
+def testForwardRaisesWhenShapesDoNotMatch() -> None:
+    """
+    测试 predictions 和 targets 形状不一致时抛出异常
+    """
+    lossFunction = MSELoss()
+
+    predictions = np.array(
+        [
+            [1.0],
+            [2.0],
+        ],
+        dtype=np.float64,
+    )
+    targets = np.array([1.0, 2.0], dtype=np.float64)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(predictions, targets)
+
+
+def testForwardRaisesWhenPredictionsIsEmpty() -> None:
+    """
+    测试 predictions 为空数组时抛出异常
+    """
+    lossFunction = MSELoss()
+
+    predictions = np.empty((0, 1), dtype=np.float64)
+    targets = np.empty((0, 1), dtype=np.float64)
+
+    with pytest.raises(ValueError):
+        lossFunction.forward(predictions, targets)
+
+
+def testBackwardRaisesWhenForwardNotCalled() -> None:
+    """
+    测试未先调用 forward 时调用 backward 会抛出异常
+    """
+    lossFunction = MSELoss()
+
+    with pytest.raises(ValueError):
+        lossFunction.backward()
+
+
+def testForwardCachesPredictionsTargetsAndElementCount() -> None:
+    """
+    测试 forward 会正确缓存中间状态
+    """
+    lossFunction = MSELoss()
+
+    predictions = np.array(
+        [
+            [1.0, 2.0],
+            [3.0, 4.0],
+        ],
+        dtype=np.float64,
+    )
+    targets = np.array(
+        [
+            [0.0, 1.0],
+            [2.0, 3.0],
+        ],
+        dtype=np.float64,
+    )
+
+    lossFunction.forward(predictions, targets)
+
+    np.testing.assert_array_equal(lossFunction.predictions, predictions)
+    np.testing.assert_array_equal(lossFunction.targets, targets)
+    assert lossFunction.elementCount == predictions.size


### PR DESCRIPTION
- 新增 MSELoss 类，实现回归任务的均方误差损失计算
- forward 阶段校验输入形状与维度，缓存 predictions、targets 及 elementCount 供 backward 复用
- backward 阶段按 2*(predictions-targets)/N 公式计算预测值梯度，未调用 forward 时抛出明确异常
- 单元测试覆盖前向损失值、反向梯度、标量输入、形状不匹配、空数组及缓存状态验证等场景
- 在 losses/__init__.py 中导出 MSELoss

close #12

## Summary by Sourcery

为回归任务添加均方误差（MSE）损失函数的实现，并通过单元测试进行覆盖。

New Features:
- 引入 `MSELoss` 类，用于计算批量预测的均方误差，并支持前向传播和反向传播。
- 从 `losses` 包中导出 `MSELoss` 损失函数。

Tests:
- 为 `MSELoss` 添加全面的测试，覆盖前向损失值、反向梯度、标量与空输入、形状校验，以及内部状态缓存行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a mean squared error (MSE) loss implementation for regression tasks and cover it with unit tests.

New Features:
- Introduce an MSELoss class that computes mean squared error for batch predictions and supports forward and backward passes.
- Export the MSELoss loss function from the losses package.

Tests:
- Add comprehensive tests for MSELoss covering forward loss values, backward gradients, scalar and empty inputs, shape validation, and internal state caching behavior.

</details>